### PR TITLE
Translate coordinator exceptions for PVOutput

### DIFF
--- a/homeassistant/components/pvoutput/coordinator.py
+++ b/homeassistant/components/pvoutput/coordinator.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from pvo import PVOutput, PVOutputAuthenticationError, PVOutputNoDataError, Status
+from pvo import (
+    PVOutput,
+    PVOutputAuthenticationError,
+    PVOutputConnectionError,
+    PVOutputError,
+    PVOutputNoDataError,
+    Status,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
@@ -37,7 +44,20 @@ class PVOutputDataUpdateCoordinator(DataUpdateCoordinator[Status]):
         """Fetch system status from PVOutput."""
         try:
             return await self.pvoutput.status()
-        except PVOutputNoDataError as err:
-            raise UpdateFailed("PVOutput has no data available") from err
         except PVOutputAuthenticationError as err:
             raise ConfigEntryAuthFailed from err
+        except PVOutputNoDataError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="no_data_available",
+            ) from err
+        except PVOutputConnectionError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+            ) from err
+        except PVOutputError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="unknown_error",
+            ) from err

--- a/homeassistant/components/pvoutput/strings.json
+++ b/homeassistant/components/pvoutput/strings.json
@@ -42,5 +42,16 @@
         "name": "Power generation"
       }
     }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the PVOutput service."
+    },
+    "no_data_available": {
+      "message": "The PVOutput service has no data available for this system."
+    },
+    "unknown_error": {
+      "message": "An unknown error occurred while communicating with the PVOutput service."
+    }
   }
 }

--- a/tests/components/pvoutput/test_init.py
+++ b/tests/components/pvoutput/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from pvo import (
     PVOutputAuthenticationError,
     PVOutputConnectionError,
+    PVOutputError,
     PVOutputNoDataError,
 )
 import pytest
@@ -37,7 +38,9 @@ async def test_load_unload_config_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.parametrize("side_effect", [PVOutputConnectionError, PVOutputNoDataError])
+@pytest.mark.parametrize(
+    "side_effect", [PVOutputConnectionError, PVOutputNoDataError, PVOutputError]
+)
 async def test_config_entry_not_ready(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
The PVOutput coordinator raised UpdateFailed with a hardcoded English message and didn't handle PVOutputConnectionError explicitly.

Replaces hardcoded string with translatable key and adds explicit error handling for connection errors.

## Type of change
- [x] Code quality improvements
