### PR TITLE
Add Sensor Platform to Duco Integration — Ventilation State, CO2, Humidity & Air Quality Monitoring

### DIFF
--- a/homeassistant/components/duco/const.py
+++ b/homeassistant/components/duco/const.py
@@ -5,5 +5,5 @@ from datetime import timedelta
 from homeassistant.const import Platform
 
 DOMAIN = "duco"
-PLATFORMS = [Platform.FAN]
+PLATFORMS = [Platform.FAN, Platform.SENSOR]
 SCAN_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/duco/icons.json
+++ b/homeassistant/components/duco/icons.json
@@ -1,0 +1,15 @@
+{
+  "entity": {
+    "sensor": {
+      "iaq_co2": {
+        "default": "mdi:molecule-co2"
+      },
+      "iaq_rh": {
+        "default": "mdi:water-percent"
+      },
+      "ventilation_state": {
+        "default": "mdi:tune-variant"
+      }
+    }
+  }
+}

--- a/homeassistant/components/duco/quality_scale.yaml
+++ b/homeassistant/components/duco/quality_scale.yaml
@@ -71,11 +71,11 @@ rules:
       Users can pair new modules (CO2 sensors, humidity sensors, zone valves)
       to their Duco box. Dynamic device support to be added in a follow-up PR.
   entity-category: todo
-  entity-device-class: todo
-  entity-disabled-by-default: todo
+  entity-device-class: done
+  entity-disabled-by-default: done
   entity-translations: done
   exception-translations: todo
-  icon-translations: todo
+  icon-translations: done
   reconfiguration-flow: todo
   repair-issues: todo
   stale-devices:

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -1,0 +1,119 @@
+"""Sensor platform for the Duco integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from duco.models import Node, NodeType, VentilationState
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION, PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import DucoConfigEntry, DucoCoordinator
+from .entity import DucoEntity
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True, kw_only=True)
+class DucoSensorEntityDescription(SensorEntityDescription):
+    """Duco sensor entity description."""
+
+    value_fn: Callable[[Node], int | float | str | None]
+    node_types: tuple[NodeType, ...]
+
+
+SENSOR_DESCRIPTIONS: tuple[DucoSensorEntityDescription, ...] = (
+    DucoSensorEntityDescription(
+        key="ventilation_state",
+        translation_key="ventilation_state",
+        device_class=SensorDeviceClass.ENUM,
+        options=[s.lower() for s in VentilationState],
+        value_fn=lambda node: (
+            node.ventilation.state.lower() if node.ventilation else None
+        ),
+        node_types=(NodeType.BOX,),
+    ),
+    DucoSensorEntityDescription(
+        key="co2",
+        device_class=SensorDeviceClass.CO2,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        value_fn=lambda node: node.sensor.co2 if node.sensor else None,
+        node_types=(NodeType.UCCO2,),
+    ),
+    DucoSensorEntityDescription(
+        key="iaq_co2",
+        translation_key="iaq_co2",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda node: node.sensor.iaq_co2 if node.sensor else None,
+        node_types=(NodeType.UCCO2,),
+    ),
+    DucoSensorEntityDescription(
+        key="humidity",
+        device_class=SensorDeviceClass.HUMIDITY,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=PERCENTAGE,
+        value_fn=lambda node: node.sensor.rh if node.sensor else None,
+        node_types=(NodeType.BSRH,),
+    ),
+    DucoSensorEntityDescription(
+        key="iaq_rh",
+        translation_key="iaq_rh",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        value_fn=lambda node: node.sensor.iaq_rh if node.sensor else None,
+        node_types=(NodeType.BSRH,),
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: DucoConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Duco sensor entities."""
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        DucoSensorEntity(coordinator, node, description)
+        for node in coordinator.data.values()
+        for description in SENSOR_DESCRIPTIONS
+        if node.general.node_type in description.node_types
+    )
+
+
+class DucoSensorEntity(DucoEntity, SensorEntity):
+    """Sensor entity for a Duco node."""
+
+    entity_description: DucoSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: DucoCoordinator,
+        node: Node,
+        description: DucoSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor entity."""
+        super().__init__(coordinator, node)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.unique_id}_{node.node_id}_{description.key}"
+        )
+
+    @property
+    def native_value(self) -> int | float | str | None:
+        """Return the sensor value."""
+        return self.entity_description.value_fn(self._node)

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -29,6 +29,36 @@
           }
         }
       }
+    },
+    "sensor": {
+      "iaq_co2": {
+        "name": "CO2 air quality index"
+      },
+      "iaq_rh": {
+        "name": "Humidity air quality index"
+      },
+      "ventilation_state": {
+        "name": "Ventilation state",
+        "state": {
+          "aut1": "Automatic boost (15 min)",
+          "aut2": "Automatic boost (30 min)",
+          "aut3": "Automatic boost (45 min)",
+          "auto": "Automatic",
+          "cnt1": "Continuous low speed",
+          "cnt2": "Continuous medium speed",
+          "cnt3": "Continuous high speed",
+          "empt": "Empty house",
+          "man1": "Manual low speed (15 min)",
+          "man1x2": "Manual low speed (30 min)",
+          "man1x3": "Manual low speed (45 min)",
+          "man2": "Manual medium speed (15 min)",
+          "man2x2": "Manual medium speed (30 min)",
+          "man2x3": "Manual medium speed (45 min)",
+          "man3": "Manual high speed (15 min)",
+          "man3x2": "Manual high speed (30 min)",
+          "man3x3": "Manual high speed (45 min)"
+        }
+      }
     }
   },
   "exceptions": {

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
-from duco.models import BoardInfo, LanInfo, Node, NodeGeneralInfo, NodeVentilationInfo
+from duco.models import (
+    BoardInfo,
+    LanInfo,
+    Node,
+    NodeGeneralInfo,
+    NodeSensorInfo,
+    NodeVentilationInfo,
+)
 import pytest
 
 from homeassistant.components.duco.const import DOMAIN
@@ -62,7 +69,7 @@ def mock_lan_info() -> LanInfo:
 
 @pytest.fixture
 def mock_nodes() -> list[Node]:
-    """Return a list with a single BOX node."""
+    """Return a list of nodes covering all supported types."""
     return [
         Node(
             node_id=1,
@@ -82,7 +89,63 @@ def mock_nodes() -> list[Node]:
                 mode="AUTO",
                 flow_lvl_tgt=0,
             ),
-        )
+            sensor=NodeSensorInfo(
+                co2=None,
+                iaq_co2=None,
+                rh=None,
+                iaq_rh=None,
+            ),
+        ),
+        Node(
+            node_id=2,
+            general=NodeGeneralInfo(
+                node_type="UCCO2",
+                sub_type=0,
+                network_type="RF",
+                parent=1,
+                asso=1,
+                name="Office CO2",
+                identify=0,
+            ),
+            ventilation=NodeVentilationInfo(
+                state="AUTO",
+                time_state_remain=0,
+                time_state_end=0,
+                mode="-",
+                flow_lvl_tgt=None,
+            ),
+            sensor=NodeSensorInfo(
+                co2=405,
+                iaq_co2=80,
+                rh=None,
+                iaq_rh=None,
+            ),
+        ),
+        Node(
+            node_id=113,
+            general=NodeGeneralInfo(
+                node_type="BSRH",
+                sub_type=0,
+                network_type="RF",
+                parent=1,
+                asso=1,
+                name="Bathroom RH",
+                identify=0,
+            ),
+            ventilation=NodeVentilationInfo(
+                state="AUTO",
+                time_state_remain=0,
+                time_state_end=0,
+                mode="-",
+                flow_lvl_tgt=None,
+            ),
+            sensor=NodeSensorInfo(
+                co2=None,
+                iaq_co2=None,
+                rh=42.0,
+                iaq_rh=85,
+            ),
+        ),
     ]
 
 

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -1,0 +1,309 @@
+# serializer version: 1
+# name: test_sensor_entities_state[sensor.bathroom_rh_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bathroom_rh_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Humidity',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_113_humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.bathroom_rh_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'humidity',
+      'friendly_name': 'Bathroom RH Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bathroom_rh_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '42.0',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.bathroom_rh_humidity_air_quality_index-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.bathroom_rh_humidity_air_quality_index',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Humidity air quality index',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Humidity air quality index',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'iaq_rh',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_113_iaq_rh',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.bathroom_rh_humidity_air_quality_index-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Bathroom RH Humidity air quality index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bathroom_rh_humidity_air_quality_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '85',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_ventilation_state-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        'auto',
+        'aut1',
+        'aut2',
+        'aut3',
+        'man1',
+        'man2',
+        'man3',
+        'empt',
+        'cnt1',
+        'cnt2',
+        'cnt3',
+        'man1x2',
+        'man2x2',
+        'man3x2',
+        'man1x3',
+        'man2x3',
+        'man3x3',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_ventilation_state',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ventilation state',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Ventilation state',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ventilation_state',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_ventilation_state',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_ventilation_state-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'enum',
+      'friendly_name': 'Living Ventilation state',
+      'options': list([
+        'auto',
+        'aut1',
+        'aut2',
+        'aut3',
+        'man1',
+        'man2',
+        'man3',
+        'empt',
+        'cnt1',
+        'cnt2',
+        'cnt3',
+        'man1x2',
+        'man2x2',
+        'man3x2',
+        'man1x3',
+        'man2x3',
+        'man3x3',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_ventilation_state',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'auto',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.office_co2_carbon_dioxide-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.office_co2_carbon_dioxide',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Carbon dioxide',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.CO2: 'carbon_dioxide'>,
+    'original_icon': None,
+    'original_name': 'Carbon dioxide',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_2_co2',
+    'unit_of_measurement': 'ppm',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.office_co2_carbon_dioxide-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'carbon_dioxide',
+      'friendly_name': 'Office CO2 Carbon dioxide',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'ppm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.office_co2_carbon_dioxide',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '405',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.office_co2_co2_air_quality_index-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.office_co2_co2_air_quality_index',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'CO2 air quality index',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'CO2 air quality index',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'iaq_co2',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_2_iaq_co2',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.office_co2_co2_air_quality_index-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Office CO2 CO2 air quality index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.office_co2_co2_air_quality_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '80',
+  })
+# ---

--- a/tests/components/duco/test_fan.py
+++ b/tests/components/duco/test_fan.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from duco.exceptions import DucoConnectionError, DucoError
 from freezegun.api import FrozenDateTimeFactory
@@ -17,7 +17,7 @@ from homeassistant.components.fan import (
     SERVICE_SET_PERCENTAGE,
     SERVICE_SET_PRESET_MODE,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
@@ -25,6 +25,20 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 _FAN_ENTITY = "fan.living"
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> MockConfigEntry:
+    """Set up only the fan platform for testing."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.duco.PLATFORMS", [Platform.FAN]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+    return mock_config_entry
 
 
 @pytest.mark.usefixtures("init_integration")

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -1,0 +1,77 @@
+"""Tests for the Duco sensor platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from duco.exceptions import DucoConnectionError
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.duco.const import SCAN_INTERVAL
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> MockConfigEntry:
+    """Set up only the sensor platform for testing."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.duco.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+    return mock_config_entry
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")
+async def test_sensor_entities_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test that sensor entities are created with the correct state."""
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_iaq_sensor_entities_disabled_by_default(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that IAQ sensor entities are disabled by default."""
+    for entity_id in (
+        "sensor.bathroom_rh_humidity_air_quality_index",
+        "sensor.office_co2_co2_air_quality_index",
+    ):
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None
+        assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_coordinator_update_marks_unavailable(
+    hass: HomeAssistant,
+    mock_duco_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that sensor entities become unavailable when the coordinator fails."""
+    mock_duco_client.async_get_nodes = AsyncMock(
+        side_effect=DucoConnectionError("offline")
+    )
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.office_co2_carbon_dioxide")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Introduction

I am excited to present this pull request which adds a comprehensive sensor platform to the existing Duco ventilation integration. This has been a labor of love and I believe it will significantly enhance the Home Assistant experience for all Duco users out there! 😊

## What Does This PR Do?

Great question! This pull request adds the following sensors for each Duco ventilation node:

1. **Ventilation State** (BOX only) — This sensor provides the current ventilation state, normalized to lowercase enum values with full translation support. It uses `SensorDeviceClass.ENUM` and displays with the `mdi:tune-variant` icon.

2. **CO2 Concentration** — For UCCO2 nodes, this sensor reports the current CO2 concentration in parts per million (ppm). It utilizes `SensorDeviceClass.CO2` for proper formatting and display.

3. **Relative Humidity** — Available for BSRH nodes, this sensor tracks the relative humidity percentage. It leverages `SensorDeviceClass.HUMIDITY`.

4. **CO2 Air Quality Index** — An Indoor Air Quality (IAQ) score expressed as a percentage (0-100%). Disabled by default.

5. **Humidity Air Quality Index** — Similar to the CO2 AQI but based on humidity readings. Disabled by default.

## Important Notes

> **Note:** Sub-nodes (UCCO2, BSRH) always reflect the same ventilation state as the BOX node, so the `ventilation_state` sensor is restricted to BOX only to avoid redundancy.

## Type of change
- [x] New feature
- [x] Code quality improvements
