### PR TITLE
⚡ Feature: Implement Historical Energy Data Backfill Support for WaterFurnace Integration

### DIFF
--- a/homeassistant/components/waterfurnace/__init__.py
+++ b/homeassistant/components/waterfurnace/__init__.py
@@ -14,6 +14,7 @@ from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, INTEGRATION_TITLE
@@ -115,10 +116,13 @@ async def _async_setup_coordinator(
     energy_coordinator = WaterFurnaceEnergyCoordinator(
         hass, device_client, entry, device_client.gwid
     )
-    # Use async_refresh() instead of async_config_entry_first_refresh() so that
-    # energy data failures (e.g. WFNoDataError for new accounts) don't block
-    # the integration from loading. Realtime sensor data is the primary concern.
-    await energy_coordinator.async_refresh()
+
+    # Defer the first energy refresh until HA has fully started so the
+    # potentially large initial backfill doesn't compete with startup I/O.
+    async def _async_start_energy(hass: HomeAssistant) -> None:
+        await energy_coordinator.async_refresh()
+
+    entry.async_on_unload(async_at_started(hass, _async_start_energy))
 
     return device_client.gwid, WaterFurnaceDeviceData(
         realtime=coordinator, energy=energy_coordinator

--- a/homeassistant/components/waterfurnace/coordinator.py
+++ b/homeassistant/components/waterfurnace/coordinator.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
+import math
+import random
 from typing import TYPE_CHECKING
 
 from waterfurnace.waterfurnace import (
@@ -38,6 +41,13 @@ if TYPE_CHECKING:
     from . import WaterFurnaceConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
+BACKFILL_BATCH_DAYS = 5
+BACKFILL_LOOKBACK_DAYS = 395  # 13 Months
+BACKFILL_GAP_THRESHOLD = timedelta(days=BACKFILL_BATCH_DAYS)
+BACKFILL_DELAY_MIN_SECONDS = 5
+BACKFILL_DELAY_MAX_SECONDS = 30
+BACKFILL_MAX_EMPTY_DAYS = 15
 
 
 @dataclass
@@ -115,6 +125,7 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
         self.client = client
         self.gwid = gwid
         self.statistic_id = f"{DOMAIN}:{gwid.lower()}_energy"
+        self._backfill_task: asyncio.Task | None = None
         self._statistic_metadata = StatisticMetaData(
             has_sum=True,
             mean_type=StatisticMeanType.NONE,
@@ -144,28 +155,43 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
         if not last_stat:
             return None
         entry = last_stat[self.statistic_id][0]
-        if entry["sum"] is None:
+        if "sum" not in entry or "start" not in entry or entry["sum"] is None:
             return None
+
         return (entry["start"], entry["sum"])
 
     def _fetch_energy_data(
         self, start_date: str, end_date: str
     ) -> list[tuple[datetime, float]]:
-        """Fetch energy data and return list of (timestamp, kWh) tuples."""
-        # Re-login to refresh the HTTP session token, which expires between
-        # the 2-hour polling intervals.
+        """Fetch energy data and return list of (timestamp, kWh) tuples.
+
+        On auth failure, re-login once and retry the request.
+        """
         try:
-            self.client.login()
-        except WFCredentialError as err:
-            raise UpdateFailed(
-                "Authentication failed during energy data fetch"
-            ) from err
-        data = self.client.get_energy_data(
-            start_date,
-            end_date,
-            frequency="1H",
-            timezone_str=self.hass.config.time_zone,
-        )
+            data = self.client.get_energy_data(
+                start_date,
+                end_date,
+                frequency="1H",
+                timezone_str=self.hass.config.time_zone,
+            )
+        except WFCredentialError:
+            try:
+                self.client.login()
+            except WFCredentialError as err:
+                raise UpdateFailed(
+                    "Authentication failed during energy data fetch"
+                ) from err
+            try:
+                data = self.client.get_energy_data(
+                    start_date,
+                    end_date,
+                    frequency="1H",
+                    timezone_str=self.hass.config.time_zone,
+                )
+            except WFCredentialError as err:
+                raise UpdateFailed(
+                    "Authentication failed during energy data fetch"
+                ) from err
         return [
             (reading.timestamp, reading.total_power)
             for reading in data
@@ -177,10 +203,14 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
         readings: list[tuple[datetime, float]],
         last_ts: float,
         last_sum: float,
-        now: datetime,
+        current_hour_ts: float | None = None,
     ) -> list[StatisticData]:
-        """Build hourly statistics from readings, skipping already-recorded ones."""
-        current_hour_ts = now.replace(minute=0, second=0, microsecond=0).timestamp()
+        """Build hourly statistics from readings, skipping already-recorded ones.
+
+        When provided, current_hour_ts acts as an exclusive cutoff so readings at
+        or after that timestamp are excluded, such as to skip the incomplete
+        current hour during normal polling and backfill.
+        """
         statistics: list[StatisticData] = []
         seen_hours: set[float] = set()
         running_sum = last_sum
@@ -188,7 +218,7 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
             ts = timestamp.timestamp()
             if ts <= last_ts:
                 continue
-            if ts >= current_hour_ts:
+            if current_hour_ts is not None and ts >= current_hour_ts:
                 continue
             hour_ts = timestamp.replace(minute=0, second=0, microsecond=0).timestamp()
             if hour_ts in seen_hours:
@@ -204,23 +234,140 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
             )
         return statistics
 
+    async def _async_backfill(
+        self,
+        start_dt: datetime,
+        end_dt: datetime,
+        initial_sum: float = 0.0,
+        last_ts: float = -math.inf,
+    ) -> None:
+        """Backfill energy statistics by walking backwards in batches.
+
+        Collects all readings into memory, then inserts them chronologically
+        in a single pass. Stops early if no data is found for
+        BACKFILL_MAX_EMPTY_DAYS consecutive days.
+        """
+        all_readings: list[tuple[datetime, float]] = []
+        batch_end = end_dt
+        local_tz = dt_util.DEFAULT_TIME_ZONE
+        consecutive_empty_days = 0
+
+        while batch_end > start_dt:
+            batch_start = max(batch_end - timedelta(days=BACKFILL_BATCH_DAYS), start_dt)
+            start_str = batch_start.astimezone(local_tz).strftime("%Y-%m-%d")
+            end_str = batch_end.astimezone(local_tz).strftime("%Y-%m-%d")
+
+            try:
+                parsed = await self.hass.async_add_executor_job(
+                    self._fetch_energy_data, start_str, end_str
+                )
+            except WFNoDataError:
+                _LOGGER.debug(
+                    "No energy data for %s to %s, skipping", start_str, end_str
+                )
+                consecutive_empty_days += BACKFILL_BATCH_DAYS
+                if consecutive_empty_days >= BACKFILL_MAX_EMPTY_DAYS:
+                    _LOGGER.debug(
+                        "No data for %d consecutive days, stopping backfill",
+                        consecutive_empty_days,
+                    )
+                    break
+                batch_end = batch_start
+                continue
+            except UpdateFailed, WFException:
+                _LOGGER.exception("Error fetching energy data during backfill")
+                break
+
+            _LOGGER.debug(
+                "Fetched %d readings for backfill batch %s to %s",
+                len(parsed),
+                start_str,
+                end_str,
+            )
+
+            all_readings.extend(parsed)
+            consecutive_empty_days = 0
+
+            batch_end = batch_start
+            if batch_end > start_dt:
+                await asyncio.sleep(
+                    random.uniform(
+                        BACKFILL_DELAY_MIN_SECONDS, BACKFILL_DELAY_MAX_SECONDS
+                    )
+                )
+
+        if all_readings:
+            # Exclude the incomplete current hour. Use local timezone so
+            # the hour boundary is correct for partial-offset timezones
+            # (e.g. UTC+5:30).
+            current_hour_ts = (
+                end_dt.astimezone(local_tz)
+                .replace(minute=0, second=0, microsecond=0)
+                .timestamp()
+            )
+            statistics = self._build_statistics(
+                all_readings, last_ts, initial_sum, current_hour_ts
+            )
+            if statistics:
+                async_add_external_statistics(
+                    self.hass, self._statistic_metadata, statistics
+                )
+
+    def _backfill_done_callback(self, task: asyncio.Task[None]) -> None:
+        """Log any exception from a completed backfill task."""
+        if task.cancelled():
+            return
+        if exc := task.exception():
+            _LOGGER.error("Backfill task failed", exc_info=exc)
+
+    async def async_wait_backfill(self) -> None:
+        """Wait for any in-progress backfill task to complete."""
+        if self._backfill_task:
+            await self._backfill_task
+
     async def _async_update_data(self) -> None:
-        """Fetch energy data and insert statistics."""
+        """Fetch energy data and insert statistics.
+
+        Handles three scenarios:
+        1. No statistics exist → first-load backfill (background task)
+        2. Last stat is older than gap threshold → gap backfill (background task)
+        3. Last stat is recent → normal poll for recent data
+        """
+        if self._backfill_task and not self._backfill_task.done():
+            _LOGGER.debug("Backfill already in progress, skipping update")
+            return
+
         last = await self._async_get_last_stat()
         now = dt_util.utcnow()
 
         if last is None:
-            _LOGGER.info("No prior statistics found, fetching recent energy data")
-            last_ts = 0.0
-            last_sum = 0.0
-            start_dt = now - timedelta(days=1)
-        else:
-            last_ts, last_sum = last
-            start_dt = dt_util.utc_from_timestamp(last_ts)
-            _LOGGER.debug("Last stat: ts=%s, sum=%s", start_dt.isoformat(), last_sum)
+            # First load: backfill walking backwards from today
+            start = now - timedelta(days=BACKFILL_LOOKBACK_DAYS)
+            self._backfill_task = self.config_entry.async_create_background_task(
+                self.hass,
+                self._async_backfill(start, now),
+                f"waterfurnace_backfill_{self.gwid}",
+            )
+            self._backfill_task.add_done_callback(self._backfill_done_callback)
+            return
 
+        last_ts, last_sum = last
+        last_dt = dt_util.utc_from_timestamp(last_ts)
+
+        if now - last_dt > BACKFILL_GAP_THRESHOLD:
+            # Large gap detected, backfill using batches
+            self._backfill_task = self.config_entry.async_create_background_task(
+                self.hass,
+                self._async_backfill(last_dt, now, last_sum, last_ts),
+                f"waterfurnace_backfill_{self.gwid}",
+            )
+            self._backfill_task.add_done_callback(self._backfill_done_callback)
+            return
+
+        # Normal poll: fetch recent data (up to BACKFILL_GAP_THRESHOLD) and insert any missing hours
+        _LOGGER.debug("Last stat: ts=%s, sum=%s", last_dt.isoformat(), last_sum)
         local_tz = dt_util.DEFAULT_TIME_ZONE
-        start_date = start_dt.astimezone(local_tz).strftime("%Y-%m-%d")
+        start_date = last_dt.astimezone(local_tz).strftime("%Y-%m-%d")
         end_date = (now.astimezone(local_tz) + timedelta(days=1)).strftime("%Y-%m-%d")
 
         try:
@@ -239,7 +386,16 @@ class WaterFurnaceEnergyCoordinator(DataUpdateCoordinator[None]):
 
         _LOGGER.debug("Fetched %s readings", len(readings))
 
-        statistics = self._build_statistics(readings, last_ts, last_sum, now)
+        # Use local timezone so the hour boundary is correct for
+        # partial-offset timezones (e.g. UTC+5:30).
+        current_hour_ts = (
+            now.astimezone(local_tz)
+            .replace(minute=0, second=0, microsecond=0)
+            .timestamp()
+        )
+        statistics = self._build_statistics(
+            readings, last_ts, last_sum, current_hour_ts
+        )
 
         _LOGGER.debug("Built %s statistics to insert", len(statistics))
 

--- a/tests/components/waterfurnace/conftest.py
+++ b/tests/components/waterfurnace/conftest.py
@@ -1,17 +1,37 @@
 """Fixtures for WaterFurnace integration tests."""
 
 from collections.abc import Generator
+from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from waterfurnace.waterfurnace import WaterFurnace, WFGateway, WFNoDataError, WFReading
 
 from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder.models import StatisticMeanType
+from homeassistant.components.recorder.models.statistics import (
+    StatisticData,
+    StatisticMetaData,
+)
+from homeassistant.components.recorder.statistics import async_add_external_statistics
 from homeassistant.components.waterfurnace.const import DOMAIN
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, UnitOfEnergy
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_conversion import EnergyConverter
 
 from tests.common import MockConfigEntry, load_json_object_fixture
+from tests.components.recorder.common import async_wait_recording_done
+
+SEED_STATISTIC_METADATA = StatisticMetaData(
+    has_sum=True,
+    mean_type=StatisticMeanType.NONE,
+    name="WaterFurnace Energy",
+    source=DOMAIN,
+    statistic_id=f"{DOMAIN}:test_gwid_12345_energy",
+    unit_class=EnergyConverter.UNIT_CLASS,
+    unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+)
 
 
 @pytest.fixture
@@ -110,6 +130,25 @@ def mock_config_entry() -> MockConfigEntry:
         version=1,
         minor_version=2,
     )
+
+
+@pytest.fixture
+async def seed_statistics(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+) -> None:
+    """Seed a recent energy statistic so the coordinator uses the normal poll path.
+
+    Without this, the energy coordinator sees no prior statistics and triggers
+    a reverse backfill on first refresh.
+    """
+    now = dt_util.utcnow()
+    # Place the seed 90 minutes back so it doesn't collide with test readings
+    start = (now - timedelta(minutes=90)).replace(minute=0, second=0, microsecond=0)
+    async_add_external_statistics(
+        hass, SEED_STATISTIC_METADATA, [StatisticData(start=start, state=0.0, sum=0.0)]
+    )
+    await async_wait_recording_done(hass)
 
 
 @pytest.fixture

--- a/tests/components/waterfurnace/test_init.py
+++ b/tests/components/waterfurnace/test_init.py
@@ -103,7 +103,7 @@ async def test_migrate_unique_id_auth_failure(
     assert old_entry.unique_id == "TEST_GWID_12345"
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("seed_statistics", "init_integration")
 async def test_unload_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -117,7 +117,7 @@ async def test_unload_entry(
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("seed_statistics", "init_integration")
 async def test_reload_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -125,15 +125,16 @@ async def test_reload_entry(
 ) -> None:
     """Test reloading a config entry."""
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_waterfurnace_client.login.call_count == 3
+    assert mock_waterfurnace_client.login.call_count == 2
 
     await hass.config_entries.async_reload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_waterfurnace_client.login.call_count == 6
+    assert mock_waterfurnace_client.login.call_count == 4
 
 
+@pytest.mark.usefixtures("seed_statistics")
 async def test_setup_creates_energy_coordinator(
     recorder_mock: Recorder,
     hass: HomeAssistant,
@@ -146,7 +147,7 @@ async def test_setup_creates_energy_coordinator(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert mock_waterfurnace_client.login.call_count == 3
+    assert mock_waterfurnace_client.login.call_count == 2
     assert mock_waterfurnace_client.read_with_retry.call_count == 1
     assert mock_waterfurnace_client.get_energy_data.call_count == 1
 

--- a/tests/components/waterfurnace/test_sensor.py
+++ b/tests/components/waterfurnace/test_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("seed_statistics", "init_integration")
 async def test_sensors(
     hass: HomeAssistant,
     mock_waterfurnace_client: Mock,
@@ -29,7 +29,7 @@ async def test_sensors(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("seed_statistics", "init_integration")
 async def test_sensor(
     hass: HomeAssistant,
     mock_waterfurnace_client: Mock,
@@ -50,7 +50,7 @@ async def test_sensor(
     assert state.state == "2000"
 
 
-@pytest.mark.usefixtures("init_integration")
+@pytest.mark.usefixtures("seed_statistics", "init_integration")
 @pytest.mark.parametrize(
     "side_effect",
     [

--- a/tests/components/waterfurnace/test_statistics.py
+++ b/tests/components/waterfurnace/test_statistics.py
@@ -1,21 +1,26 @@
 """Tests for WaterFurnace energy statistics."""
 
 from datetime import datetime, timedelta
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
-from waterfurnace.waterfurnace import WFCredentialError, WFEnergyData
+from waterfurnace.waterfurnace import WFCredentialError, WFEnergyData, WFNoDataError
 
 from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder.models.statistics import StatisticData
 from homeassistant.components.recorder.statistics import (
     StatisticsRow,
+    async_add_external_statistics,
+    get_last_statistics,
     statistics_during_period,
 )
 from homeassistant.components.waterfurnace.const import DOMAIN, ENERGY_UPDATE_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
+
+from .conftest import SEED_STATISTIC_METADATA
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.recorder.common import async_wait_recording_done
@@ -54,6 +59,17 @@ async def _get_stats(
     return stats.get(STATISTIC_ID, [])
 
 
+async def _get_last_stat(hass: HomeAssistant) -> StatisticsRow | None:
+    """Get the most recent statistic."""
+    last = await hass.async_add_executor_job(
+        get_last_statistics, hass, 1, STATISTIC_ID, True, {"sum"}
+    )
+    rows = last.get(STATISTIC_ID)
+    if not rows:
+        return None
+    return rows[0]
+
+
 async def _trigger_energy_poll(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory
 ) -> None:
@@ -71,7 +87,39 @@ async def _trigger_energy_poll(
     await async_wait_recording_done(hass)
 
 
+async def _setup_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Set up the integration and wait for background tasks to settle."""
+    mock_config_entry.add_to_hass(hass)
+    with (
+        patch(
+            "homeassistant.components.waterfurnace.coordinator.BACKFILL_DELAY_MIN_SECONDS",
+            0,
+        ),
+        patch(
+            "homeassistant.components.waterfurnace.coordinator.BACKFILL_DELAY_MAX_SECONDS",
+            0,
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+        for device_data in mock_config_entry.runtime_data.values():
+            if device_data.energy:
+                await device_data.energy.async_wait_backfill()
+    await async_wait_recording_done(hass)
+    await hass.async_block_till_done()
+    await async_wait_recording_done(hass)
+
+
+# ---------------------------------------------------------------------------
+# Normal poll tests (seed_statistics fixture ensures no backfill is triggered)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.freeze_time(NOW)
+@pytest.mark.usefixtures("seed_statistics")
 async def test_poll_inserts_statistics(
     recorder_mock: Recorder,
     hass: HomeAssistant,
@@ -79,28 +127,22 @@ async def test_poll_inserts_statistics(
     mock_waterfurnace_client: Mock,
 ) -> None:
     """Test that energy data is fetched and inserted as statistics."""
-    t1 = _NOW_DT - timedelta(hours=2)
-    t2 = _NOW_DT - timedelta(hours=1)
-
+    t1 = _NOW_DT - timedelta(hours=1)
     mock_waterfurnace_client.get_energy_data.side_effect = None
     mock_waterfurnace_client.get_energy_data.return_value = _make_energy_data(
-        [(t1, 2.0), (t2, 3.0)]
+        [(t1, 3.0)]
     )
 
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-    await async_wait_recording_done(hass)
+    await _setup_integration(hass, mock_config_entry)
 
-    entries = await _get_stats(hass, t1, t2 + timedelta(seconds=1))
-    assert len(entries) == 2
-    assert entries[0]["state"] == pytest.approx(2.0)
-    assert entries[0]["sum"] == pytest.approx(2.0)
-    assert entries[1]["state"] == pytest.approx(3.0)
-    assert entries[1]["sum"] == pytest.approx(5.0)
+    entries = await _get_stats(hass, t1, t1 + timedelta(seconds=1))
+    assert len(entries) == 1
+    assert entries[0]["state"] == pytest.approx(3.0)
+    assert entries[0]["sum"] == pytest.approx(3.0)
 
 
 @pytest.mark.freeze_time(NOW)
+@pytest.mark.usefixtures("seed_statistics")
 async def test_poll_skips_current_hour(
     recorder_mock: Recorder,
     hass: HomeAssistant,
@@ -116,16 +158,14 @@ async def test_poll_skips_current_hour(
         [(t_completed, 2.0), (t_current, 5.0)]
     )
 
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-    await async_wait_recording_done(hass)
+    await _setup_integration(hass, mock_config_entry)
 
     entries = await _get_stats(hass, t_completed, t_current + timedelta(seconds=1))
     assert len(entries) == 1
     assert entries[0]["sum"] == pytest.approx(2.0)
 
 
+@pytest.mark.usefixtures("seed_statistics")
 async def test_poll_empty_response(
     recorder_mock: Recorder,
     hass: HomeAssistant,
@@ -136,14 +176,13 @@ async def test_poll_empty_response(
     mock_waterfurnace_client.get_energy_data.side_effect = None
     mock_waterfurnace_client.get_energy_data.return_value = _make_energy_data([])
 
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    await _setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.freeze_time(NOW)
+@pytest.mark.usefixtures("seed_statistics")
 async def test_subsequent_poll_resumes_sum(
     recorder_mock: Recorder,
     hass: HomeAssistant,
@@ -153,18 +192,14 @@ async def test_subsequent_poll_resumes_sum(
 ) -> None:
     """Test that subsequent polls correctly resume from the last recorded sum."""
     t1 = _NOW_DT - timedelta(hours=1)
-
     mock_waterfurnace_client.get_energy_data.side_effect = None
     mock_waterfurnace_client.get_energy_data.return_value = _make_energy_data(
         [(t1, 4.0)]
     )
 
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-    await async_wait_recording_done(hass)
+    await _setup_integration(hass, mock_config_entry)
 
-    # Advance time so t2 becomes a completed hour, then poll again
+    # Advance time so t2 becomes available, then poll again
     t2 = _NOW_DT
     mock_waterfurnace_client.get_energy_data.return_value = _make_energy_data(
         [(t2, 6.0)]
@@ -185,14 +220,13 @@ async def test_no_data_error_handled_gracefully(
 ) -> None:
     """Test that WFNoDataError does not prevent integration setup."""
     # Default conftest sets get_energy_data.side_effect = WFNoDataError
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    await _setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.freeze_time(NOW)
+@pytest.mark.usefixtures("seed_statistics")
 async def test_login_credential_error_raises_update_failed(
     recorder_mock: Recorder,
     hass: HomeAssistant,
@@ -201,16 +235,15 @@ async def test_login_credential_error_raises_update_failed(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that WFCredentialError during energy login raises UpdateFailed."""
-    # First setup succeeds with no data
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
+    await _setup_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    # On next poll, login fails with credential error
+    # On next poll, get_energy_data fails with expired session, then
+    # re-login also fails with credential error.
+    mock_waterfurnace_client.get_energy_data.side_effect = WFCredentialError(
+        "session expired"
+    )
     mock_waterfurnace_client.login.side_effect = WFCredentialError("bad creds")
-    mock_waterfurnace_client.get_energy_data.side_effect = None
 
     await _trigger_energy_poll(hass, freezer)
 
@@ -219,6 +252,7 @@ async def test_login_credential_error_raises_update_failed(
 
 
 @pytest.mark.freeze_time(NOW)
+@pytest.mark.usefixtures("seed_statistics")
 async def test_timezone_conversion(
     recorder_mock: Recorder,
     hass: HomeAssistant,
@@ -228,24 +262,196 @@ async def test_timezone_conversion(
     """Test that energy data is correctly handled across time zones."""
     await hass.config.async_set_time_zone("America/New_York")
 
-    t1 = _NOW_DT - timedelta(hours=2)
-    t2 = _NOW_DT - timedelta(hours=1)
-
+    t1 = _NOW_DT - timedelta(hours=1)
     mock_waterfurnace_client.get_energy_data.side_effect = None
     mock_waterfurnace_client.get_energy_data.return_value = _make_energy_data(
-        [(t1, 1.5), (t2, 2.5)]
+        [(t1, 1.5)]
     )
 
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-    await async_wait_recording_done(hass)
+    await _setup_integration(hass, mock_config_entry)
 
-    entries = await _get_stats(hass, t1, t2 + timedelta(seconds=1))
-    assert len(entries) == 2
+    entries = await _get_stats(hass, t1, t1 + timedelta(seconds=1))
+    assert len(entries) == 1
     assert entries[0]["sum"] == pytest.approx(1.5)
-    assert entries[1]["sum"] == pytest.approx(4.0)
 
     # Verify the API was called with dates in the configured timezone
     call_args = mock_waterfurnace_client.get_energy_data.call_args
     assert call_args.kwargs.get("timezone_str") == "America/New_York"
+
+
+# ---------------------------------------------------------------------------
+# Backfill tests (no seed_statistics — these intentionally trigger backfill)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.freeze_time(NOW)
+async def test_first_poll_no_statistics_triggers_reverse_backfill(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_waterfurnace_client: Mock,
+) -> None:
+    """Test first poll with no existing statistics triggers reverse backfill."""
+    t1 = _NOW_DT - timedelta(hours=2)
+
+    def side_effect(start: str, end: str, **kwargs: str) -> WFEnergyData:
+        if start <= t1.strftime("%Y-%m-%d") <= end:
+            return _make_energy_data([(t1, 5.0)])
+        raise WFNoDataError("No data")
+
+    mock_waterfurnace_client.get_energy_data.side_effect = side_effect
+
+    await _setup_integration(hass, mock_config_entry)
+
+    last = await _get_last_stat(hass)
+    assert last is not None
+    assert last["sum"] == pytest.approx(5.0)
+
+
+@pytest.mark.freeze_time(NOW)
+async def test_gap_backfill(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_waterfurnace_client: Mock,
+) -> None:
+    """Test gap backfill when last stat is older than gap threshold."""
+    t0 = _NOW_DT - timedelta(days=7)
+    async_add_external_statistics(
+        hass,
+        SEED_STATISTIC_METADATA,
+        [StatisticData(start=t0, state=1.0, sum=10.0)],
+    )
+    await async_wait_recording_done(hass)
+
+    t1 = _NOW_DT - timedelta(days=5)
+    t2 = _NOW_DT - timedelta(days=1)
+    mock_waterfurnace_client.get_energy_data.side_effect = None
+    mock_waterfurnace_client.get_energy_data.return_value = _make_energy_data(
+        [(t1, 2.0), (t2, 3.0)]
+    )
+
+    await _setup_integration(hass, mock_config_entry)
+
+    last = await _get_last_stat(hass)
+    assert last is not None
+    assert last["sum"] == pytest.approx(15.0)
+
+
+@pytest.mark.freeze_time(NOW)
+async def test_reverse_backfill_stops_on_no_data(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_waterfurnace_client: Mock,
+) -> None:
+    """Test that WFNoDataError during reverse backfill skips gaps."""
+    t1 = _NOW_DT - timedelta(hours=2)
+
+    def side_effect(start: str, end: str, **kwargs: str) -> WFEnergyData:
+        if start <= t1.strftime("%Y-%m-%d") <= end:
+            return _make_energy_data([(t1, 7.0)])
+        raise WFNoDataError("No data")
+
+    mock_waterfurnace_client.get_energy_data.side_effect = side_effect
+
+    await _setup_integration(hass, mock_config_entry)
+
+    # Reverse backfill continues past WFNoDataError gaps, so it should
+    # have made more calls than just the one successful batch.
+    assert mock_waterfurnace_client.get_energy_data.call_count > 2
+
+    last = await _get_last_stat(hass)
+    assert last is not None
+    assert last["sum"] == pytest.approx(7.0)
+
+
+@pytest.mark.freeze_time(NOW)
+async def test_reverse_backfill_early_stop_on_consecutive_empty(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_waterfurnace_client: Mock,
+) -> None:
+    """Test that reverse backfill stops after BACKFILL_MAX_EMPTY_DAYS with no data."""
+    mock_waterfurnace_client.get_energy_data.side_effect = WFNoDataError("No data")
+
+    await _setup_integration(hass, mock_config_entry)
+
+    # 15 empty days / 5-day batches = 3 batches before early stop,
+    # not the full 79 batches for 395 days.
+    assert mock_waterfurnace_client.get_energy_data.call_count == 3
+
+
+@pytest.mark.freeze_time(NOW)
+async def test_backfill_then_normal_poll(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_waterfurnace_client: Mock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that backfill followed by normal poll produces correct cumulative sums."""
+    t0 = _NOW_DT - timedelta(days=6)
+    async_add_external_statistics(
+        hass,
+        SEED_STATISTIC_METADATA,
+        [StatisticData(start=t0, state=1.0, sum=100.0)],
+    )
+    await async_wait_recording_done(hass)
+
+    t1 = _NOW_DT - timedelta(days=4)
+    t2 = _NOW_DT - timedelta(days=1)
+    mock_waterfurnace_client.get_energy_data.side_effect = None
+    mock_waterfurnace_client.get_energy_data.return_value = _make_energy_data(
+        [(t1, 2.0), (t2, 3.0)]
+    )
+
+    await _setup_integration(hass, mock_config_entry)
+
+    # Now do a normal poll (last stat is now recent)
+    t3 = _NOW_DT
+    mock_waterfurnace_client.get_energy_data.return_value = _make_energy_data(
+        [(t3, 4.0)]
+    )
+    await _trigger_energy_poll(hass, freezer)
+
+    last = await _get_last_stat(hass)
+    assert last is not None
+    assert last["sum"] == pytest.approx(109.0)
+
+
+@pytest.mark.freeze_time(NOW)
+async def test_backfill_multi_batch_running_totals(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_waterfurnace_client: Mock,
+) -> None:
+    """Test multi-day backfill produces correct running totals across batches."""
+    t0 = _NOW_DT - timedelta(days=8)
+    async_add_external_statistics(
+        hass,
+        SEED_STATISTIC_METADATA,
+        [StatisticData(start=t0, state=0.0, sum=50.0)],
+    )
+    await async_wait_recording_done(hass)
+
+    t1 = _NOW_DT - timedelta(days=6)
+    t2 = _NOW_DT - timedelta(days=3)
+    t3 = _NOW_DT - timedelta(days=1)
+
+    def side_effect(start: str, end: str, **kwargs: str) -> WFEnergyData:
+        results = []
+        for t, kwh in ((t1, 10.0), (t2, 20.0), (t3, 30.0)):
+            if start <= t.strftime("%Y-%m-%d") < end:
+                results.append((t, kwh))
+        return _make_energy_data(results)
+
+    mock_waterfurnace_client.get_energy_data.side_effect = side_effect
+
+    await _setup_integration(hass, mock_config_entry)
+
+    last = await _get_last_stat(hass)
+    assert last is not None
+    assert last["sum"] == pytest.approx(110.0)


### PR DESCRIPTION
## 🌟 Introduction

Hello reviewers! 👋 I am thrilled to submit this pull request that adds comprehensive energy data backfill capabilities to the WaterFurnace integration. This feature represents a significant step forward in providing users with complete and actionable energy consumption data.

## 📊 Problem Statement

Currently, the WaterFurnace integration only captures energy data from the point of initial setup onwards. This means that valuable historical energy consumption data that already exists on the WaterFurnace platform remains inaccessible within Home Assistant. This limitation prevents users from getting a complete picture of their energy usage patterns.

## 🔄 Solution Architecture

The solution implements a multi-phase backfill strategy within the `WaterFurnaceEnergyCoordinator`:

### Phase 1: Initial Historical Data Seeding
On first load, the system walks backwards through time for up to 13 months, fetching hourly energy data to seed a comprehensive historical baseline.

### Phase 2: Gap Detection and Recovery
On subsequent updates, the system intelligently detects data gaps and performs targeted backfill operations from the last recorded statistic to the current time.

### Phase 3: Intelligent Batching
When data gaps exceed 5 days, the system automatically batches API requests to ensure efficient data retrieval while respecting rate limits.

## ⚠️ Known Limitations

There is one known limitation: if the WaterFurnace system has an energy data gap exceeding 15 days, the backfill process will treat that as the end of available data.

## Type of change
- [x] New feature
